### PR TITLE
Add login functionality

### DIFF
--- a/backend/core/data.go
+++ b/backend/core/data.go
@@ -24,5 +24,22 @@ type Comment struct {
 	Reply        string
 }
 
+type UserLogin struct {
+	Mail     string `json:"mail" bson:"mail"`
+	Password string `json:"password" bson:"password"`
+}
+
+func (u *User)IsEmpty() bool {
+	isEmpty := true
+
+	isEmpty = isEmpty && (u.Username == "")
+	isEmpty = isEmpty && (u.Name == "")
+	isEmpty = isEmpty && (u.Surname == "")
+	isEmpty = isEmpty && (u.Mail == "")
+	isEmpty = isEmpty && (u.Password == "")
+
+	return isEmpty
+}
+
 var postMock = Post{Title: "This is a test title", Body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean ultricies, tortor consectetur rhoncus sodales, arcu eros sollicitudin est, ac viverra lorem lectus at ligula. Nulla tempus tortor purus. In eget est bibendum, accumsan urna ultrices, porta eros. Cras ut congue lorem, non pulvinar dolor. Quisque sit amet sapien malesuada, aliquam purus quis, aliquam ligula. Etiam tristique, tortor vel tincidunt lacinia, est tortor pellentesque neque, ac pretium nisl sapien quis elit. Vestibulum eleifend velit fringilla pellentesque euismod. Duis fringilla dapibus velit, id mattis leo facilisis sit amet. Sed interdum euismod finibus.", Date: "01/01/1970", Author: "John Doe"}
 var postMocks = []Post{postMock, {Title: "This is a new test title", Body: "Some ugly written text with cringe content.", Date: "01/01/1969", Author: "Booby Hobby"}}

--- a/backend/core/response.go
+++ b/backend/core/response.go
@@ -18,7 +18,7 @@ func (er *ErrorResponse) Respond() {
 		er.RaisedError = fmt.Errorf("")
 	}
 
-	errorMessage := fmt.Sprintf("%d - %s. %s", er.StatusCode, er.Message, er.RaisedError.Error())
+	errorMessage := fmt.Sprintf("%d - %s. reason: %s", er.StatusCode, er.Message, er.RaisedError.Error())
 
 	(*er.ResponseWriter).WriteHeader(er.StatusCode)
 	(*er.ResponseWriter).Header().Set("X-Status-Reason", errorMessage)

--- a/backend/database/database.go
+++ b/backend/database/database.go
@@ -3,20 +3,55 @@ package database
 // @TODO: Implement context related code
 
 import (
+	"context"
 	"digitalpaper/backend/core"
+	"os"
+	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 // Configuration parameters
 var noFilterCriteria = bson.D{}
+const databaseName = "digital_paper"
 
 type Database struct {
 	app      *core.Application
 	Posts    *mongo.Collection
 	Users    *mongo.Collection
 	Sessions *mongo.Collection
+}
+
+func (db *Database) Connect(dbUrl string) error {
+	clientOptions := options.Client().ApplyURI(dbUrl)
+	clientOptions.SetServerSelectionTimeout(3 * time.Second)
+	client, err := mongo.Connect(context.TODO(), clientOptions)
+
+	if err != nil {
+		return err
+	}
+
+	// Check if the database connection is alive
+	if err := client.Ping(context.TODO(), nil); err != nil {
+		return err
+	}
+
+	// In a local dev environment (non-Docker), fetching the given environment variable 
+	// could return in an empty string and would not properly initialize the database
+	database := os.Getenv("MONGO_INITDB_DATABASE")
+	if database == "" {
+		database = databaseName
+	}
+
+	db.Posts = client.Database(database).Collection("posts")
+	db.Users = client.Database(database).Collection("users")
+	db.Sessions = client.Database(database).Collection("sessions")
+
+	db.app.Log.Info("Database connection established")
+
+	return nil
 }
 
 func NewDatabase(app *core.Application, dbUrl string) (*Database, error) {
@@ -30,3 +65,4 @@ func NewDatabase(app *core.Application, dbUrl string) (*Database, error) {
 
 	return database, nil
 }
+

--- a/backend/database/posts.go
+++ b/backend/database/posts.go
@@ -4,40 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
-	"time"
 
 	"digitalpaper/backend/core"
 
 	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
 )
-
-func (db *Database) Connect(dbUrl string) error {
-	clientOptions := options.Client().ApplyURI(dbUrl)
-	clientOptions.SetServerSelectionTimeout(3 * time.Second)
-	client, err := mongo.Connect(context.TODO(), clientOptions)
-
-	if err != nil {
-		return err
-	}
-
-	// Check if the database connection is alive
-	if err := client.Ping(context.TODO(), nil); err != nil {
-		return err
-	}
-
-	database := os.Getenv("MONGO_INITDB_DATABASE")
-
-	db.Posts = client.Database(database).Collection("posts")
-	db.Users = client.Database(database).Collection("users")
-	db.Sessions = client.Database(database).Collection("sessions")
-
-	db.app.Log.Info("Database connection established")
-
-	return nil
-}
 
 func (db Database) CreatePost(ctx *context.Context, post *core.Post) error {
 	_, err := db.Posts.InsertOne(context.TODO(), post)

--- a/backend/web/routes.go
+++ b/backend/web/routes.go
@@ -34,6 +34,7 @@ func (r Routes) HandleRequests() *mux.Router {
 	// POST
 	router.Path("/posts").Methods(http.MethodPost).Handler(dynamicMiddleware.ThenFunc(r.Handlers.createPost))
 	router.Path("/users").Methods(http.MethodPost).Handler(dynamicMiddleware.ThenFunc(r.Handlers.createUser))
+	router.Path("/login").Methods(http.MethodPost).Handler(dynamicMiddleware.ThenFunc(r.Handlers.login))
 
 	// PUT
 	router.Path("/posts").Methods(http.MethodPut).Handler(dynamicMiddleware.ThenFunc(r.Handlers.editPost))


### PR DESCRIPTION
This PR implements the login functionality. When we enter the wrong credentials, we get appropriate responses from the server. In order to check it, enter a custom user. Example:
```shell
curl -i -X POST -d '{"username":"samba", "mail":"somemail@mail.com", "name":"klikle", "surname":"lile", "password":"hidden"}' http://localhost:3500
```
When we try to log in with a mistyped or wrong mail, the following response is shown
```shell
$ curl -i -X POST -d '{"mail":"somemail23@mail.co", "password":"hidden"}' http://localhost:3500/login

HTTP/1.1 404 Not Found
Vary: Origin
Vary: Cookie
X-Status-Reason: 404 - error while login. reason:
Date: Fri, 09 Dec 2022 15:14:30 GMT
Content-Length: 0
```

By entering the wrong password, the following response is shown:
```shell
$curl -i -X POST -d '{"mail":"somemail23@mail.com", "password":"hidden2"}' http://localhost:3500/login

HTTP/1.1 406 Not Acceptable
Vary: Origin
Vary: Cookie
X-Status-Reason: 406 - . reason: wrong credentials
Date: Fri, 09 Dec 2022 15:14:43 GMT
Content-Length: 0
```

If everything is correct, a `OK` response is returned with the session token:
```shell
$ curl -i -X POST -d '{"mail":"somemail23@mail.com", "password":"hidden"}' http://localhost:3500/login 

HTTP/1.1 200 OK
Cache-Control: no-cache="Set-Cookie"
Set-Cookie: session=GZa5HvjZSP351CoXtdo-WYovYPEsnIwZf2rMTb4Rto8; Path=/; Expires=Sat, 10 Dec 2022 03:15:02 GMT; Max-Age=43200; HttpOnly; SameSite=Lax
Vary: Origin
Vary: Cookie
Date: Fri, 09 Dec 2022 15:15:01 GMT
Content-Length: 0
```