### PR TITLE
Implement protected middleware layer

### DIFF
--- a/backend/web/middleware.go
+++ b/backend/web/middleware.go
@@ -1,0 +1,35 @@
+package web
+
+import (
+	"digitalpaper/backend/core"
+	"fmt"
+	"net/http"
+)
+
+type Middleware struct {
+	App *core.Application
+}
+
+func NewMiddleware(app *core.Application) *Middleware {
+	middleware := &Middleware{}
+
+	middleware.App = app
+
+	return middleware
+}
+
+func (m *Middleware) RequireAuthentication(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if !m.App.SessionManager.Exists(req.Context(), "authenticatedUserId") {
+			errorResponse := core.ErrorResponse{ResponseWriter: &w, RaisedError: fmt.Errorf(""), StatusCode: http.StatusForbidden}
+			errorResponse.Respond()
+
+			m.App.Log.Error(errorResponse.Message)
+
+			return
+		}
+
+		w.Header().Add("Cache-Control", "no-store")
+		next.ServeHTTP(w, req)
+	})
+}


### PR DESCRIPTION
Add a middleware layer that allows only authorized users to execute CRUD operations on users and posts.

Test workflow:

1. Login with a valid user
```shell
curl -i --c fake_cookie_data.txt -b fake_cookie_data.txt -X POST -d '{"mail":"somemail23@mail.com", "password":"hidden"}' http://localhost:3500/login
```
2. Add a new post:
```shell
curl -i --cookie-jar fake_cookie_data.txt --cookie fake_cookie_data.txt -X POST --data '{"title": "A nice title", "body":"Floor gang", "author":"OOh"}' -H 'Content-Type: application/json' http://localhost:3500/posts
```
The server should respond with an `OK` status.

3. Logout:
```shell
curl -i --c fake_cookie_data.txt -b fake_cookie_data.txt -X POST -d '{"id":"2659274f-612b-4d22-a7d1-e2c3da95dc8d"}' http://localhost:3500/logout
```

4. Try to add a new post like above, only this time the server should respond with a `403 Forbidden` status.

